### PR TITLE
(Feature) Allow multiple random-address generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "src/index.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ require('yargs')
     }
   )
   .command(
-    ['randomAddress', 'ra'],
+    ['random-address', 'ra'],
     'Prints a random ethereum address',
     () => {},
     () => {

--- a/src/index.js
+++ b/src/index.js
@@ -106,12 +106,12 @@ require('yargs')
   )
   .command(
     ['random-address', 'ra'],
-    'Prints a random ethereum address',
+    'Prints a random Ethereum checksum address',
     () => {},
     () => {
       const utils = require('web3-utils')
 
-      const address = utils.randomHex(20)
+      const address = utils.toChecksumAddress(utils.randomHex(20))
 
       console.log(address)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -105,15 +105,22 @@ require('yargs')
     }
   )
   .command(
-    ['random-address', 'ra'],
-    'Prints a random Ethereum checksum address',
-    () => {},
-    () => {
+    ['random-address [amount]', 'ra'],
+    'Prints a random Ethereum checksum address. [amount] can be specified to generate a list of addresses.',
+    yargs => {
+      yargs
+        .positional('amount', { default: 1 })
+    },
+    argv => {
       const utils = require('web3-utils')
+      const amount = parseInt(argv.amount)
 
-      const address = utils.toChecksumAddress(utils.randomHex(20))
-
-      console.log(address)
+      if (!isNaN(amount) && amount > 0) {
+        for (let i = 0; i < amount; i++) {
+          const address = utils.toChecksumAddress(utils.randomHex(20))
+          console.log(address)
+        }
+      }
     }
   )
   .strict()


### PR DESCRIPTION
This PR changes the `randomAddress` command to `random-address`, to maintain a consistency with commands naming of `eth-cli`.

Now returns the checksummed Ethereum address.

And adds the option to specify the amount of addresses to be randomly generated.
```
$ eth random-address 10
0xfBC8256f2D3dB9dF79F9443783a98fE5690f5528
0x22862aeB499bA24fEcc6c470D9d5e10340A1c184
0x66b13a8cDF90f1F1eBfdA66Fec8178ACB5fDC85a
0x018fB555B648c35c207Ae7Cc1991411c9F21DA91
0x0B0602b21546B8Fb1e6B1f5C99C64d072A4B2293
0xEb95807DcF75d75bC3b42a891E90Aa76a40bF374
0xE19dc0f699b4Ed8c20F4C7E33e1b126763Ba6395
0x9b3691c862164b67c15cB3A7E00d98D872330d2C
0x0Ad4A2384731B5482e717AdB3cdEd018089255Ed
0xCC403B99539D2d0C3A3054E773D5808368b548A4
```