### PR TITLE
Add build, npm, license and dependencies badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # eth-cli
 
+[![Build Status](https://travis-ci.org/protofire/eth-cli.svg?branch=master)](https://travis-ci.org/protofire/eth-cli)
+[![NPM version](https://badge.fury.io/js/eth-cli.svg)](https://npmjs.org/package/eth-cli)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/protofire/eth-cli/master/LICENSE)
+[![dependencies Status](https://david-dm.org/protofire/eth-cli/status.svg)](https://david-dm.org/protofire/eth-cli)
+[![devDependencies Status](https://david-dm.org/protofire/eth-cli/dev-status.svg)](https://david-dm.org/protofire/eth-cli?type=dev)
+
 A collection of CLI tools to help with ethereum learning and development.
 
 ## REPL


### PR DESCRIPTION
This PR adds a few badges:
- Travis CI build
- NPM package
- License
- Dependencies
- Dev dependencies