### PR TITLE
Add nop command

### DIFF
--- a/src/decodeTxData.js
+++ b/src/decodeTxData.js
@@ -1,4 +1,5 @@
 const Web3 = require('web3')
+const { add0x } = require('./utils')
 const web3 = new Web3()
 const abi = web3.eth.abi
 
@@ -11,10 +12,7 @@ module.exports = function(functionSignature, txData) {
 
   const encodedFunctionSignature = abi.encodeFunctionSignature(functionSignature)
 
-  // Normalize txData
-  if (!/^0x/.test(txData)) {
-    txData = '0x' + txData
-  }
+  txData = add0x(txData)
 
   const txDataRegex = new RegExp('^' + encodedFunctionSignature)
 

--- a/src/generateNop.js
+++ b/src/generateNop.js
@@ -1,8 +1,5 @@
 const Web3 = require('web3')
-
-function add0x(hex) {
-  return hex.indexOf('0x') === 0 ? hex : `0x${hex}`
-}
+const { add0x } = require('./utils')
 
 module.exports = function(url, privateKey) {
   const web3 = new Web3(new Web3.providers.HttpProvider(url))

--- a/src/generateNop.js
+++ b/src/generateNop.js
@@ -1,0 +1,20 @@
+const Web3 = require('web3')
+
+function add0x(hex) {
+  return hex.indexOf('0x') === 0 ? hex : `0x${hex}`
+}
+
+module.exports = function(url, privateKey) {
+  const web3 = new Web3(new Web3.providers.HttpProvider(url))
+  privateKey = add0x(privateKey)
+
+  const { address } = web3.eth.accounts.wallet.add(privateKey)
+
+  return web3.eth
+    .sendTransaction({
+      from: address,
+      to: address,
+      gas: 21000
+    })
+    .then(result => result.transactionHash)
+}

--- a/src/getContractAddress.js
+++ b/src/getContractAddress.js
@@ -1,25 +1,18 @@
 const sha3 = require('ethereumjs-util').sha3
 const rlp = require('rlp')
+const { add0x } = require('./utils')
 
 module.exports = function(_address, _nonce) {
   if (!_address) {
     throw new Error('address is required')
   }
 
-  const address = normalizeAddress(_address)
+  const address = add0x(_address)
   const nonce = Number(_nonce || 0)
 
   const contractAddress = sha3(rlp.encode([address, nonce]))
     .toString('hex')
     .slice(24)
 
-  return normalizeAddress(contractAddress)
-}
-
-function normalizeAddress(address) {
-  if (address[0] === '0' && (address[1] === 'x' || address[1] === 'X')) {
-    return address
-  }
-
-  return '0x' + address
+  return add0x(contractAddress)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -207,6 +207,21 @@ yargs
       )
     }
   )
+  .command(
+    ['nop <pk>'],
+    'Generates a transaction that does nothing with the given private key',
+    yargs => {
+      yargs.positional('pk', { required: true })
+    },
+    argv => {
+      const generateNop = require('./generateNop')
+      const { pk, url } = argv
+
+      generateNop(url, pk).then(tx => {
+        console.log(tx)
+      })
+    }
+  )
   .command({
     command: 'network',
     desc: 'Allows actions with known networks',

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,3 +13,7 @@ module.exports.showDataWithDisplay = (data, display) => {
     console.log(JSON.stringify(data, null, 2))
   }
 }
+
+module.exports.add0x = hex => {
+  return hex.indexOf('0x') === 0 ? hex : `0x${hex}`
+}


### PR DESCRIPTION
Adds `nop` command, that generates a dummy transaction using the given private key:

```
$ eth nop 63e48a8ba0b99e0377c6b483af4a072cbca5ffbcfdac77be72e69f4960125800
0xb387d1ccce9ea070ef846b5c531959bd0a0dd40eab504f7892890822da2eb1f6
```

Useful for generating blocks in dev chains with auto-mining.

---

Ideally this would be a subcommand for `eth tx`: `eth tx nop <private-key>` (and the current `eth tx` could be `eth tx get <tx-hash>`), but that is something we can do later (maybe when/if we change yargs for oclif).