### PR TITLE
Add RSK network and infer network flags from networks constants

### DIFF
--- a/src/networks.js
+++ b/src/networks.js
@@ -1,18 +1,37 @@
-module.exports.networksIds = {
-  mainnet: 1,
-  ropsten: 3,
-  rinkeby: 4,
-  kovan: 42,
-  sokol: 77,
-  poa: 99
-}
-
-module.exports.networksUrls = {
-  mainnet: 'https://mainnet.infura.io',
-  ropsten: 'https://ropsten.infura.io',
-  rinkeby: 'https://rinkeby.infura.io',
-  kovan: 'https://kovan.infura.io',
-  sokol: 'https://sokol.poa.network',
-  poa: 'https://core.poa.network',
-  local: 'http://localhost:8545'
+module.exports = {
+  mainnet: {
+    id: 1,
+    url: 'https://mainnet.infura.io',
+    label: 'Mainnet'
+  },
+  ropsten: {
+    id: 3,
+    url: 'https://ropsten.infura.io',
+    label: 'Ropsten'
+  },
+  rinkeby: {
+    id: 4,
+    url: 'https://rinkeby.infura.io',
+    label: 'Rinkeby'
+  },
+  rsk: {
+    id: 31,
+    url: 'https://public-node.testnet.rsk.co',
+    label: 'RSK'
+  },
+  kovan: {
+    id: 42,
+    url: 'https://kovan.infura.io',
+    label: 'Kovan'
+  },
+  sokol: {
+    id: 77,
+    url: 'https://sokol.poa.network',
+    label: 'Sokol'
+  },
+  poa: {
+    id: 99,
+    url: 'https://core.poa.network',
+    label: 'POA'
+  }
 }

--- a/src/networks.js
+++ b/src/networks.js
@@ -15,9 +15,14 @@ module.exports = {
     label: 'Rinkeby'
   },
   rsk: {
+    id: 30,
+    url: 'https://public-node.rsk.co',
+    label: 'RSK'
+  },
+  'rsk-testnet': {
     id: 31,
     url: 'https://public-node.testnet.rsk.co',
-    label: 'RSK'
+    label: 'RSK testnet'
   },
   kovan: {
     id: 42,


### PR DESCRIPTION
Add RSK network. Also, we had some duplication between the networks flags registration and the definition of the networks, so now the single source of truth is the `networks.js` file. The flags will be inferred from there.

I also removed the `local` network since I don't think it's useful. If someone was relying on it, please let me know.