### PR TITLE
Add 'methods' command

### DIFF
--- a/src/getMethods.js
+++ b/src/getMethods.js
@@ -1,0 +1,18 @@
+const sha3 = require('ethereumjs-util').sha3
+const { loadABI } = require('./utils')
+
+module.exports = function(abiPath) {
+  let abi = loadABI(abiPath)
+
+  const methods = abi.filter(x => x.type === 'function' && x.name).map(({ name, inputs }) => {
+    const params = inputs.map(x => x.type).join(',')
+    const signature = `${name}(${params})`
+    const signatureHash = sha3(signature)
+      .toString('hex')
+      .slice(0, 8)
+
+    return { signature, signatureHash }
+  })
+
+  return methods
+}

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,25 @@ yargs
     }
   )
   .command(
+    'methods <abi>',
+    'Get the hash of each method in the given ABI',
+    yargs => {
+      yargs.positional('abi', {
+        required: true
+      })
+    },
+    argv => {
+      const getMethods = require('./getMethods')
+      const { abi } = argv
+
+      const methods = getMethods(abi)
+
+      methods.forEach(({ signature, signatureHash }) => {
+        console.log(`${signatureHash}\t${signature}`)
+      })
+    }
+  )
+  .command(
     ['contract-address <account> [nonce]', 'ca'],
     'Get the address for a contract created from the given address with the given nonce',
     yargs => {

--- a/src/loadContract.js
+++ b/src/loadContract.js
@@ -1,6 +1,6 @@
-const fs = require('fs')
 const path = require('path')
 const replStarter = require('./replStarter')
+const { loadABI } = require('./utils')
 const Web3 = require('web3')
 
 module.exports = function(abiPath, address, rest, url) {
@@ -11,7 +11,7 @@ module.exports = function(abiPath, address, rest, url) {
   let abisAndAddresses = [
     {
       abiPath: abiPath,
-      abi: parseAbi(abiPath),
+      abi: loadABI(abiPath),
       address: address
     }
   ]
@@ -20,7 +20,7 @@ module.exports = function(abiPath, address, rest, url) {
     const [abiPath, address] = rest.slice(i, i + 2)
     abisAndAddresses.push({
       abiPath: abiPath,
-      abi: parseAbi(abiPath),
+      abi: loadABI(abiPath),
       address: address
     })
   }
@@ -52,25 +52,4 @@ module.exports = function(abiPath, address, rest, url) {
 
   // Start REPL
   replStarter(rplContext)
-}
-
-function parseAbi(abiPath) {
-  const abiStr = fs.readFileSync(abiPath).toString()
-
-  let abi = null
-
-  try {
-    abi = JSON.parse(abiStr)
-
-    // Allow using truffle artifacts files too.
-    // If abi variable it's an object and it has an abi property, interpret it as a truffle artifact
-    if (abi !== null && typeof abi === 'object' && abi.abi) {
-      abi = abi.abi
-    }
-  } catch (e) {
-    console.log('Error parsing abi', e)
-    process.exit(1)
-  }
-
-  return abi
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 module.exports.showDataWithDisplay = (data, display) => {
   if (display.toLowerCase() === 'table') {
     const Table = require('cli-table')
@@ -16,4 +17,25 @@ module.exports.showDataWithDisplay = (data, display) => {
 
 module.exports.add0x = hex => {
   return hex.indexOf('0x') === 0 ? hex : `0x${hex}`
+}
+
+module.exports.loadABI = abiPath => {
+  const abiStr = fs.readFileSync(abiPath).toString()
+
+  let abi = null
+
+  try {
+    abi = JSON.parse(abiStr)
+
+    // Allow using truffle artifacts files too.
+    // If abi variable it's an object and it has an abi property, interpret it as a truffle artifact
+    if (abi.abi) {
+      abi = abi.abi
+    }
+  } catch (e) {
+    console.log('Error parsing abi', e)
+    process.exit(1)
+  }
+
+  return abi
 }


### PR DESCRIPTION
With this new command you can obtain the first four bytes of the hash of each method's signature:

```
$ eth methods ERC20.json
18160ddd	totalSupply()
70a08231	balanceOf(address)
a9059cbb	transfer(address,uint256)
dd62ed3e	allowance(address,address)
23b872dd	transferFrom(address,address,uint256)
095ea7b3	approve(address,uint256)
```

Use case example: you have a transaction to a contract and you want to know which method was called by that transaction. You can grep the beginning of the `input` of the transaction to find out:

```
$ eth methods ERC20.json | grep a9059
a9059cbb	transfer(address,uint256)
```