### PR TITLE
Add 'deploy' command

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -1,0 +1,28 @@
+const fs = require('fs')
+const Web3 = require('web3')
+const { add0x } = require('./utils')
+
+module.exports = function(url, privateKey, bin) {
+  const web3 = new Web3(new Web3.providers.HttpProvider(url))
+  privateKey = add0x(privateKey)
+
+  const { address } = web3.eth.accounts.wallet.add(privateKey)
+
+  const data = add0x(fs.readFileSync(bin).toString())
+
+  const contract = new web3.eth.Contract([])
+
+  const deploy = contract.deploy({ data })
+
+  return deploy
+    .estimateGas({
+      from: address
+    })
+    .then(gas => {
+      return deploy.send({
+        from: address,
+        gas
+      })
+    })
+    .then(contract => contract.options.address)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -234,6 +234,20 @@ yargs
       })
     }
   )
+  .command(
+    ['deploy <pk> <bin>'],
+    'Deploy contract whose bytecode is in <bin> using private key <pk>',
+    yargs => {
+      yargs.positional('pk', { required: true })
+      yargs.positional('bin', { required: true })
+    },
+    argv => {
+      const deploy = require('./deploy')
+      const { bin, pk, url } = argv
+
+      deploy(url, pk, bin).then(console.log).catch(console.error)
+    }
+  )
   .command({
     command: 'network',
     desc: 'Allows actions with known networks',


### PR DESCRIPTION
Closes #16.

Usage: `eth deploy <private-key> <path-to-bin>`. The output is the address of the deployed contract.

This needs the contract to be compiled before. Example (assuming you started `ganache-cli -d` in another terminal):

```
$ echo 'contract Foo { uint256 public foo = 42; }' > Foo.sol
$ solcjs --bin Foo.sol
$ eth deploy 4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d Foo_sol_Foo.bin
0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab
$ solcjs --abi Foo.sol
$ eth lc Foo_sol_Foo.abi 0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab
> Foo_sol_Foo.methods.foo().call()
'42'
```