### PR TITLE
Add `send-transaction`, `encode` and `send` methods

### DIFF
--- a/src/encode.js
+++ b/src/encode.js
@@ -1,0 +1,33 @@
+const { extractMethodObjectsFromABI, loadABI } = require('./utils')
+const Web3 = require('web3')
+
+module.exports = function(abiPath, methodCall, url) {
+  if (!methodCall) {
+    throw new Error('[encode] methodCall required')
+  }
+
+  const isValidMethod = /^(\w+)\((.*)\)$/
+  const method = isValidMethod.exec(methodCall)
+
+  if (!method) {
+    throw new Error('[encode] methodCall invalid structure')
+  }
+
+  const methodName = method[1]
+  const abi = loadABI(abiPath)
+  const matchingMethods = extractMethodObjectsFromABI(abi).filter(x => x.name === methodName)
+
+  if (matchingMethods.length > 1) {
+    throw new Error('[encode] function overloading is not supported in the current version')
+  }
+
+  if (!matchingMethods.length) {
+    throw new Error('[encode] method specified does not exist in the ABI file provided')
+  }
+
+  const web3 = new Web3(new Web3.providers.HttpProvider(url))
+  // `contract` is being used as part of the eval call
+  // eslint-disable-next-line no-unused-vars
+  const contract = new web3.eth.Contract(abi)
+  return eval(`contract.methods.${methodCall}.encodeABI()`)
+}

--- a/src/encode.js
+++ b/src/encode.js
@@ -1,4 +1,4 @@
-const { extractMethodObjectsFromABI, loadABI } = require('./utils')
+const { extractMethodObjectsFromABI, loadABI, evaluateMethodCallStructure } = require('./utils')
 const Web3 = require('web3')
 
 module.exports = function(abiPath, methodCall, url) {
@@ -6,14 +6,12 @@ module.exports = function(abiPath, methodCall, url) {
     throw new Error('[encode] methodCall required')
   }
 
-  const isValidMethod = /^(\w+)\((.*)\)$/
-  const method = isValidMethod.exec(methodCall)
+  const { methodValid, methodName } = evaluateMethodCallStructure(methodCall)
 
-  if (!method) {
+  if (!methodValid) {
     throw new Error('[encode] methodCall invalid structure')
   }
 
-  const methodName = method[1]
   const abi = loadABI(abiPath)
   const matchingMethods = extractMethodObjectsFromABI(abi).filter(x => x.name === methodName)
 

--- a/src/getMethods.js
+++ b/src/getMethods.js
@@ -1,10 +1,10 @@
 const sha3 = require('ethereumjs-util').sha3
-const { loadABI } = require('./utils')
+const { loadABI, extractMethodObjectsFromABI } = require('./utils')
 
 module.exports = function(abiPath) {
   let abi = loadABI(abiPath)
 
-  const methods = abi.filter(x => x.type === 'function' && x.name).map(({ name, inputs }) => {
+  const methods = extractMethodObjectsFromABI(abi).map(({ name, inputs }) => {
     const params = inputs.map(x => x.type).join(',')
     const signature = `${name}(${params})`
     const signatureHash = sha3(signature)

--- a/src/index.js
+++ b/src/index.js
@@ -114,10 +114,10 @@ yargs
           },
           handler: argv => {
             const encode = require('./encode')
-            const sendTx = require('./sendTransaction')
+            const sendTransaction = require('./sendTransaction')
             const { abi, methodCall, address, pk, url } = argv
 
-            sendTx(encode(abi, methodCall, url), address, pk, url)
+            sendTransaction(encode(abi, methodCall, url), address, pk, url)
               .then(console.log)
               .catch(console.error)
           }

--- a/src/sendTransaction.js
+++ b/src/sendTransaction.js
@@ -1,0 +1,25 @@
+const { add0x } = require('./utils')
+const Web3 = require('web3')
+
+module.exports = function(data, contractAddress, privateKey, url) {
+  const web3 = new Web3(new Web3.providers.HttpProvider(url))
+
+  privateKey = add0x(privateKey)
+  contractAddress = add0x(contractAddress)
+
+  const { address } = web3.eth.accounts.wallet.add(privateKey)
+
+  return new Promise((resolve, reject) => {
+    const tx = { from: address, data: data, to: contractAddress }
+    web3.eth
+      .estimateGas(tx)
+      .then(gas => {
+        tx.gas = gas
+        web3.eth
+          .sendTransaction(tx)
+          .on('transactionHash', resolve)
+          .on('error', reject)
+      })
+      .catch(reject)
+  })
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,3 +39,7 @@ module.exports.loadABI = abiPath => {
 
   return abi
 }
+
+module.exports.extractMethodObjectsFromABI = function(abi) {
+  return abi.filter(x => x.type === 'function' && x.name)
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,3 +43,25 @@ module.exports.loadABI = abiPath => {
 module.exports.extractMethodObjectsFromABI = function(abi) {
   return abi.filter(x => x.type === 'function' && x.name)
 }
+
+/**
+ * Evaluates a method call structure and returns an object with the information validated
+ * @param methodCall
+ * @returns {{
+ *  methodCall: (string|null),
+ *  methodName: (string|null),
+ *  methodArgs: (string|null),
+ *  methodValid: boolean
+ * }}
+ */
+module.exports.evaluateMethodCallStructure = function(methodCall) {
+  const isValidMethod = /^(\w+)\((.*)\)$/
+  const method = isValidMethod.exec(methodCall)
+
+  return {
+    methodCall,
+    methodName: method ? method[1] : null,
+    methodArgs: method ? method[2] : null,
+    methodValid: !!method
+  }
+}


### PR DESCRIPTION
Closes #39 

All commands where grouped under `method` command, and the functionality for the `method` command was moved under the sub-command `hash`.

### hash
Usage: `eth method hash <signature>`
Aliases: `h`, `hs`
```
$ eth m h 'transfer(address,uint256)'
a9059cbb
```

### encode
Usage: `eth method encode <abiPath> <methodCall>`
Aliases: `e`
```
$ eth method encode ./Contract.abi 'foo("a","0x...",1,[[1],"j"])'
0x55f865010000000...
```

### send-transaction
Usage: `eth method st <encodedABI> <contractAddress> <privateKey>`
Returns: `transactionHash`
Aliases: `st`
```
$ eth method st 0x55f865010000000... 0x5f8e2... 4f3edf983ac636a65a842ce7c7...
0x1d7566c23128dd8645c5f033fef37a33d312b5833666726522b2970e0614841d
```

### send
Usage: `eth method send <abiPath> <methodCall> <contractAddress> <privateKey>`
Its a simplified combination of `send-transaction` and `encode` as was suggested in the original issue.
Aliases: `s`
```
$ eth m s ./Contract.abi 'foo(1,2)' 0x5f8e2... 4f3edf983ac636a65a842...
0xfe0b89b94706a4e056fb94a57c28c1f1ac2acdd971f8bae90b29f336919cac21
```
it's equivalent to:
```
$ eth m st `eth m e ./Contract.abi 'foo(1,2)'` 0x5f8e2... 4f3edf983ac636a65a842...
0x907026b2dc582276533b618484edd5bfdf66dd12fe683fd087bc03f917c5e483
```