### PR TITLE
Call `.toString` in BigNumber values

### DIFF
--- a/src/helpers/decodeTxData.ts
+++ b/src/helpers/decodeTxData.ts
@@ -34,7 +34,7 @@ export function decodeTxData(functionSignature: string, txData: string) {
 
   const result = []
   for (let i = 0; i < Object.keys(args).length; i++) {
-    const value = isBN(args[i]) ? args[i].toString() : args[i];
+    const value = isBN(args[i]) ? args[i].toString() : args[i]
     result.push(value)
   }
 

--- a/src/helpers/decodeTxData.ts
+++ b/src/helpers/decodeTxData.ts
@@ -1,6 +1,6 @@
 import Web3 from 'web3'
 
-import { add0x } from './utils'
+import { add0x, isBN } from './utils'
 
 export function decodeTxData(functionSignature: string, txData: string) {
   const paramsRegex = /^[^(].*\((.*)\)$/
@@ -34,7 +34,8 @@ export function decodeTxData(functionSignature: string, txData: string) {
 
   const result = []
   for (let i = 0; i < Object.keys(args).length; i++) {
-    result.push(args[i])
+    const value = isBN(args[i]) ? args[i].toString() : args[i];
+    result.push(value)
   }
 
   return result

--- a/src/helpers/replStarter.ts
+++ b/src/helpers/replStarter.ts
@@ -4,6 +4,8 @@ import * as repl from 'repl'
 import * as vm from 'vm'
 import Web3 from 'web3'
 
+import { isBN } from './utils'
+
 const historyFile = path.join(os.homedir(), '.eth_cli_history')
 
 export function replStarter(context: { [key: string]: any }) {
@@ -16,7 +18,17 @@ export function replStarter(context: { [key: string]: any }) {
         })
 
         if (result && result.then) {
-          result.then((x: any) => callback(null, x)).catch((e: Error) => callback(e, null))
+          result
+            .then((x: any) => {
+              if (x && isBN(x)) {
+                callback(null, x.toString())
+                return
+              }
+              callback(null, x)
+            })
+            .catch((e: Error) => callback(e, null))
+        } else if (result && isBN(result)) {
+          callback(null, result.toString())
         } else {
           callback(null, result)
         }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -80,3 +80,5 @@ const createAccount = () => {
 
   return wallet.create(1, randomBytes(32).toString('hex'))[0]
 }
+
+export const isBN = (x: any) => x._hex !== undefined

--- a/test/commands/__snapshots__/decode.spec.ts.snap
+++ b/test/commands/__snapshots__/decode.spec.ts.snap
@@ -5,9 +5,7 @@ exports[`decode Should run 'decode 'transfer(address,uint256)'
 Array [
   "[
   \\"0x697dB915674bAc602F4d6fAfA31c0e45f386416E\\",
-  {
-    \\"_hex\\": \\"0x04ff043b9e\\"
-  }
+  \\"21458336670\\"
 ]
 ",
 ]


### PR DESCRIPTION
Only in `repl` and in `decode` commands. There might be other places where this is necessary.