### PR TITLE
Add private key flag for REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,9 +355,12 @@ receipt object if the transaction was mined, or will be null otherwise.
 Generate a transaction that does nothing (it sends 0 ETH to itself) using the given private key:
 
 ```
-$ eth tx:nop --kovan 0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
+$ eth tx:nop --kovan --pk 0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
 "0x7f3f2967b93a7eded18071a596b7f3987c9575b6bae0a19399725c19e793517b"
 ```
+
+**As with all commands that use a private key, this should only be used for
+testing. `eth-cli` is NOT meant to be used with real assets**
 
 ### `repl`
 

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -54,7 +54,7 @@ export abstract class BaseCommand extends Command {
     const networksInfo = BaseCommand.getNetworksInfo()
 
     for (const flag of Object.keys(flags) as Array<keyof typeof flags>) {
-      if (flag === 'url') continue
+      if (flag === 'url' || !BaseCommand.flags[flag]) continue
 
       if (flags[flag]) {
         return [networksInfo[flag].url, flag]

--- a/src/commands/method/send-transaction.ts
+++ b/src/commands/method/send-transaction.ts
@@ -1,12 +1,14 @@
 import { cli } from 'cli-ux'
 
 import { BaseCommand } from '../../base'
+import { privateKeyFlag } from '../../flags'
 
 export default class SendTransactionCommand extends BaseCommand {
-  static description = `Sends the transaction for the contract in <address> with <encodedABI> using private key <pk>.`
+  static description = `Sends the transaction for the contract in <address> with <encodedABI> using the given private key.`
 
   static flags = {
     ...BaseCommand.flags,
+    pk: { ...privateKeyFlag, required: true },
   }
 
   static args = [
@@ -20,14 +22,9 @@ export default class SendTransactionCommand extends BaseCommand {
       required: true,
       description: `The contract's address.`,
     },
-    {
-      name: 'pk',
-      required: true,
-      description: 'The private key.',
-    },
   ]
 
-  static examples = ['eth method:send-transaction']
+  static examples = ['eth method:send-transaction --pk 0x6db0bdfc7800dcf87b5a88b3363997360395d36ef51db10c3458d51d8aefd37e 0xa9059cbb000000000000000000000000b2e4a264a982039f8e503ea3c83af5537f583069000000000000000000000000da480b4852ca3ade4acf3eeca6901952edbae912 0x15503FBAb2fa57535092ab9c24740142Ab6cabd3']
 
   static aliases = ['m:st']
 
@@ -39,9 +36,10 @@ export default class SendTransactionCommand extends BaseCommand {
     try {
       networkUrl = this.getNetworkUrl(flags)
 
-      const { encodedABI, address, pk } = args
+      const { encodedABI, address } = args
+      const { pk } = flags
       const { sendTransaction } = await import('../../helpers/sendTransaction')
-      const result = await sendTransaction(encodedABI, address, pk, networkUrl)
+      const result = await sendTransaction(encodedABI, address, pk!, networkUrl)
 
       cli.styledJSON(result)
     } catch (e) {

--- a/src/commands/method/send-transaction.ts
+++ b/src/commands/method/send-transaction.ts
@@ -24,7 +24,9 @@ export default class SendTransactionCommand extends BaseCommand {
     },
   ]
 
-  static examples = ['eth method:send-transaction --pk 0x6db0bdfc7800dcf87b5a88b3363997360395d36ef51db10c3458d51d8aefd37e 0xa9059cbb000000000000000000000000b2e4a264a982039f8e503ea3c83af5537f583069000000000000000000000000da480b4852ca3ade4acf3eeca6901952edbae912 0x15503FBAb2fa57535092ab9c24740142Ab6cabd3']
+  static examples = [
+    'eth method:send-transaction --pk 0x6db0bdfc7800dcf87b5a88b3363997360395d36ef51db10c3458d51d8aefd37e 0xa9059cbb000000000000000000000000b2e4a264a982039f8e503ea3c83af5537f583069000000000000000000000000da480b4852ca3ade4acf3eeca6901952edbae912 0x15503FBAb2fa57535092ab9c24740142Ab6cabd3',
+  ]
 
   static aliases = ['m:st']
 

--- a/src/commands/method/send.ts
+++ b/src/commands/method/send.ts
@@ -1,12 +1,14 @@
 import { cli } from 'cli-ux'
 
 import { BaseCommand } from '../../base'
+import { privateKeyFlag } from '../../flags'
 
 export default class SendCommand extends BaseCommand {
-  static description = `Executes <methodCall> for the contract in <address> given <abi> using private key <pk>.`
+  static description = `Executes <methodCall> for the contract in <address> given <abi> using the given private key.`
 
   static flags = {
     ...BaseCommand.flags,
+    pk: { ...privateKeyFlag, required: true },
   }
 
   static args = [
@@ -25,14 +27,11 @@ export default class SendCommand extends BaseCommand {
       required: true,
       description: `The contract's  address.`,
     },
-    {
-      name: 'pk',
-      required: true,
-      description: 'The private key.',
-    },
   ]
 
-  static examples = ['eth method:send']
+  static examples = [
+    `eth method:send erc20 'transfer("0xb2E4a264A982039f8E503ea3C83af5537f583069", "0xDa480B4852ca3aDE4acF3eeCA6901952EdbAe912")' 0x15503FBAb2fa57535092ab9c24740142Ab6cabd3 0x6db0bdfc7800dcf87b5a88b3363997360395d36ef51db10c3458d51d8aefd37e`,
+  ]
 
   static aliases = ['m:s']
 
@@ -44,11 +43,12 @@ export default class SendCommand extends BaseCommand {
     try {
       networkUrl = this.getNetworkUrl(flags)
 
-      const { abi, methodCall, address, pk } = args
+      const { abi, methodCall, address } = args
+      const { pk } = flags
       const { encode } = await import('../../helpers/encode')
       const { sendTransaction } = await import('../../helpers/sendTransaction')
       const abiByteCode = encode(abi, methodCall, networkUrl)
-      const result = await sendTransaction(abiByteCode, address, pk, networkUrl)
+      const result = await sendTransaction(abiByteCode, address, pk!, networkUrl)
 
       cli.styledJSON(result)
     } catch (e) {

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -1,6 +1,5 @@
-import { flags } from '@oclif/command'
-
 import { BaseCommand } from '../base'
+import { privateKeyFlag } from '../flags'
 
 const parseReplContracts = (args: string[]): Array<{ abiPath: string; address: string }> => {
   const result = args.map(arg => {
@@ -28,10 +27,7 @@ learn how to do this.`
 
   static flags = {
     ...BaseCommand.flags,
-    pk: flags.string({
-      description: 'Private key to unlock',
-      env: 'ETH_CLI_PRIVATE_KEY',
-    }),
+    pk: privateKeyFlag,
   }
 
   static args = [

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -1,3 +1,5 @@
+import { flags } from '@oclif/command'
+
 import { BaseCommand } from '../base'
 
 const parseReplContracts = (args: string[]): Array<{ abiPath: string; address: string }> => {
@@ -26,6 +28,10 @@ learn how to do this.`
 
   static flags = {
     ...BaseCommand.flags,
+    pk: flags.string({
+      description: 'Private key to unlock',
+      env: 'ETH_CLI_PRIVATE_KEY',
+    }),
   }
 
   static args = [
@@ -55,9 +61,11 @@ learn how to do this.`
           : `${networkFlag}> `
 
       const contracts = parseReplContracts(argv)
+      const privateKey = flags.pk
+
       const { startRepl } = await import('../helpers/startRepl')
 
-      startRepl(networkUrl, prompt, contracts)
+      startRepl(networkUrl, prompt, contracts, privateKey)
     } catch (e) {
       this.error(e.message, { exit: 1 })
     }

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -45,15 +45,19 @@ learn how to do this.`
 
   async run() {
     const { flags, argv } = this.parse(ReplCommand)
-    let networkUrl
-
     try {
-      networkUrl = this.getNetworkUrl(flags)
+      const [networkUrl, networkFlag] = this.getNetworkUrlAndFlag(flags)
+      const prompt =
+        networkFlag === 'url'
+          ? networkUrl === BaseCommand.defaultUrl
+            ? '> '
+            : `${networkUrl}> `
+          : `${networkFlag}> `
 
       const contracts = parseReplContracts(argv)
       const { startRepl } = await import('../helpers/startRepl')
 
-      startRepl(networkUrl, contracts)
+      startRepl(networkUrl, prompt, contracts)
     } catch (e) {
       this.error(e.message, { exit: 1 })
     }

--- a/src/commands/transaction/nop.ts
+++ b/src/commands/transaction/nop.ts
@@ -1,38 +1,33 @@
 import { cli } from 'cli-ux'
 
 import { BaseCommand } from '../../base'
+import { privateKeyFlag } from '../../flags'
 
 export default class NopCommand extends BaseCommand {
   static description = `Generates a transaction that does nothing with the given private key.`
 
   static flags = {
     ...BaseCommand.flags,
+    pk: { ...privateKeyFlag, required: true },
   }
 
-  static args = [
-    {
-      name: 'pk',
-      required: true,
-      description: 'The private key.',
-    },
-  ]
-
   static examples = [
-    'eth transaction:nop 3daa79a26454a5528a3523f9e6345efdbd636e63f8c24a835204e6ccb5c88f9e',
+    'eth transaction:nop --pk 3daa79a26454a5528a3523f9e6345efdbd636e63f8c24a835204e6ccb5c88f9e',
+    'ETH_CLI_PRIVATE_KEY=3daa79a26454a5528a3523f9e6345efdbd636e63f8c24a835204e6ccb5c88f9e eth transaction:nop',
   ]
 
   static aliases = ['tx:nop']
 
   async run() {
-    const { args, flags } = this.parse(NopCommand)
+    const { flags } = this.parse(NopCommand)
     let networkUrl
 
     try {
       networkUrl = this.getNetworkUrl(flags)
 
-      const { pk } = args
+      const { pk } = flags
       const { generateNop } = await import('../../helpers/generateNop')
-      const tx = await generateNop(networkUrl, pk)
+      const tx = await generateNop(networkUrl, pk!)
 
       cli.styledJSON(tx)
     } catch (e) {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,0 +1,6 @@
+import { flags } from '@oclif/command'
+
+export const privateKeyFlag = flags.string({
+  description: 'Private key to unlock. Can also be specified using the ETH_CLI_PRIVATE_KEY environment variable.',
+  env: 'ETH_CLI_PRIVATE_KEY',
+})

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command'
 
 export const privateKeyFlag = flags.string({
-  description: 'Private key to unlock. Can also be specified using the ETH_CLI_PRIVATE_KEY environment variable.',
+  description:
+    'Private key to unlock. Can also be specified using the ETH_CLI_PRIVATE_KEY environment variable.',
   env: 'ETH_CLI_PRIVATE_KEY',
 })

--- a/src/helpers/replStarter.ts
+++ b/src/helpers/replStarter.ts
@@ -6,9 +6,9 @@ import Web3 from 'web3'
 
 const historyFile = path.join(os.homedir(), '.eth_cli_history')
 
-export function replStarter(context: { [key: string]: any }) {
+export function replStarter(context: { [key: string]: any }, prompt: string) {
   const r = repl.start({
-    prompt: '> ',
+    prompt,
     eval: (cmd, context, _, callback) => {
       try {
         const result = vm.runInContext(cmd, context, {

--- a/src/helpers/startRepl.ts
+++ b/src/helpers/startRepl.ts
@@ -12,6 +12,7 @@ export function startRepl(
   url: string,
   prompt: string,
   contracts: Array<{ abiPath: string; address: string }>,
+  privateKey: string | undefined,
 ) {
   if (!url) {
     throw new Error('[startRepl] URL require')
@@ -19,6 +20,10 @@ export function startRepl(
 
   // Connect web3
   const web3 = new Web3(new Web3.providers.HttpProvider(url))
+
+  if (privateKey) {
+    web3.eth.accounts.wallet.add(privateKey)
+  }
 
   // Default context
   let replContext: ReplContext = {

--- a/src/helpers/startRepl.ts
+++ b/src/helpers/startRepl.ts
@@ -8,7 +8,11 @@ interface ReplContext {
   [key: string]: any
 }
 
-export function startRepl(url: string, contracts: Array<{ abiPath: string; address: string }>) {
+export function startRepl(
+  url: string,
+  prompt: string,
+  contracts: Array<{ abiPath: string; address: string }>,
+) {
   if (!url) {
     throw new Error('[startRepl] URL require')
   }
@@ -40,5 +44,5 @@ export function startRepl(url: string, contracts: Array<{ abiPath: string; addre
   }
 
   // Start REPL
-  replStarter(replContext)
+  replStarter(replContext, prompt)
 }

--- a/test/commands/method/send-transaction.spec.ts
+++ b/test/commands/method/send-transaction.spec.ts
@@ -18,10 +18,9 @@ describe('send-transaction', () => {
 
   it(`Should run 'send-transacion' and throw an error.`, async () => {
     await expect(MethodSendTransactionCommand.run([])).rejects.toThrow(
-      'Missing 3 required args:\n' +
+      'Missing 2 required args:\n' +
         'encodedABI  The encoded ABI.\n' +
         "address     The contract's address.\n" +
-        'pk          The private key.\n' +
         'See more help with --help',
     )
   })

--- a/test/commands/method/send.spec.ts
+++ b/test/commands/method/send.spec.ts
@@ -18,11 +18,10 @@ describe('send', () => {
 
   it(`Should run 'send' and throw an error.`, async () => {
     await expect(MethodSendCommand.run([])).rejects.toThrow(
-      'Missing 4 required args:\n' +
+      'Missing 3 required args:\n' +
         "abi         The contract's ABI.\n" +
         'methodCall  e.g.: \'myMethod(arg1,arg2,["a","b",3,["d","0x123..."]])\'\n' +
         "address     The contract's  address.\n" +
-        'pk          The private key.\n' +
         'See more help with --help',
     )
   })

--- a/test/commands/transaction/nop.spec.ts
+++ b/test/commands/transaction/nop.spec.ts
@@ -16,25 +16,7 @@ describe('transaction:nop', () => {
     await expect(TransactionNopCommand.run()).rejects.toThrow()
   })
 
-  it(`Should run 'transaction:nop' and throw an error.`, async () => {
-    await expect(TransactionNopCommand.run([])).rejects.toThrow(
-      'Missing 1 required arg:\n' + 'pk  The private key.\n' + 'See more help with --help',
-    )
-  })
-
   it(`Should run 'transaction:nop --help' and throw an error.`, async () => {
     await expect(TransactionNopCommand.run(['--help'])).rejects.toThrow('EEXIT: 0')
-  })
-
-  it(`Should run 'transaction:nop --bar' without url and throw an error.`, async () => {
-    await expect(TransactionNopCommand.run(['--bar'])).rejects.toThrow(
-      `Cannot read property 'fromRed' of null`,
-    )
-  })
-
-  it(`Should run 'transaction:nop --bar' and throw an error.`, async () => {
-    await expect(TransactionNopCommand.run(['--ropsten', '--bar'])).rejects.toThrow(
-      `Cannot read property 'fromRed' of null`,
-    )
   })
 })


### PR DESCRIPTION
Depends on #63.

This PR adds a `--pk` flag to the REPL command that allows starting the REPL with the account of that private key unlocked.

The flag can also be specified using the `ETH_CLI_PRIVATE_KEY` variable. This lets you do this neat trick in your `.bashrc`:

```
alias eth='ETH_CLI_PRIVATE_KEY=0x123... eth'
```

For consistency, the `eth tx:nop`, `eth method:send` and `eth method:send-transaction`, that were using an argument for the private key, now use a flag.

## Cute animal picture

![image](https://user-images.githubusercontent.com/417134/59125844-ddde8600-8939-11e9-9f01-a39f4e5cd596.png)
