### PR TITLE
Add load command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,15 @@ node_js:
 services:
   - docker
 
-script:
-  - npm run lint
-  - npm test
-  - npm run commitlint-travis
-  - cd e2e && ./run-tests.sh
-
 jobs:
   include:
+    - stage: test
+      node_js: "8"
+      script:
+        - npm run lint
+        - npm test
+        - npm run commitlint-travis
+        - cd e2e && ./run-tests.sh
     - stage: release
       node_js: "8"
       script: echo "Running semantic-release..."

--- a/src/helpers/replStarter.ts
+++ b/src/helpers/replStarter.ts
@@ -8,7 +8,7 @@ import { isBN } from './utils'
 
 const historyFile = path.join(os.homedir(), '.eth_cli_history')
 
-export function replStarter(context: { [key: string]: any }, prompt: string) {
+export function replStarter(context: { [key: string]: any }, prompt: string): repl.REPLServer {
   const r = repl.start({
     prompt,
     eval: (cmd, context, _, callback) => {
@@ -49,6 +49,8 @@ export function replStarter(context: { [key: string]: any }, prompt: string) {
   }
 
   require('repl.history')(r, historyFile)
+
+  return r
 }
 
 function isRecoverableError(error: Error) {

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,10 @@
     "file-name-casing": false,
     "binary-expression-operand-order": false,
     "no-http-string": false,
-    "no-implicit-dependencies": [true, ["web3-core", "web3-eth", "web3-eth-contract", "web3-utils"]]
+    "no-implicit-dependencies": [
+      true,
+      ["web3-core", "web3-eth", "web3-eth-contract", "web3-utils"]
+    ],
+    "no-console": false
   }
 }


### PR DESCRIPTION
Depends on #82.

Add a `.loadc` command to the repl. This lets you load new contracts after starting the REPL:

```
$ eth repl --mainnet
mainnet> .loadc erc20@0xf5dce57282a584d2746faf1593d3121fcac444dc
mainnet> erc20.methods.totalSupply().call()
'158719983240907434'
```

## Cute animal picture

![image](https://user-images.githubusercontent.com/417134/62316997-1a78ba80-b46f-11e9-9200-d7a244e0eb51.png)

