### PR TITLE
Common url flag

### DIFF
--- a/src/base/help-command.ts
+++ b/src/base/help-command.ts
@@ -2,6 +2,9 @@ import { Command as BaseCommand } from '@oclif/command'
 
 import { isEmptyCommand } from '../helpers/checkCommandInputs'
 
+/**
+ * Base command for "partial" commands that, when called, only show their help.
+ */
 export default class HelpCommand extends BaseCommand {
   async run() {
     const { args, flags } = this.parse(this.constructor as any)

--- a/src/base/network.ts
+++ b/src/base/network.ts
@@ -6,10 +6,13 @@ interface NetworkInfo {
   label?: string
 }
 
-type NetworkFlag = keyof typeof BaseCommand.flags
+type NetworkFlag = keyof typeof NetworkCommand.flags
 type NetworkName = Exclude<NetworkFlag, 'url'>
 
-export abstract class BaseCommand extends Command {
+/**
+ * Base command that handles the flags used for specifying the desired network.
+ */
+export abstract class NetworkCommand extends Command {
   static flags = {
     url: flags.string(),
     mainnet: flags.boolean({ exclusive: ['url'] }),
@@ -39,28 +42,28 @@ export abstract class BaseCommand extends Command {
     }
   }
 
-  getNetworkUrl(flags: { [key in keyof typeof BaseCommand.flags]: any }): string {
+  getNetworkUrl(flags: { [key in keyof typeof NetworkCommand.flags]: any }): string {
     const [networkUrl] = this.getNetworkUrlAndFlag(flags)
     return networkUrl
   }
 
   getNetworkUrlAndFlag(
-    flags: { [key in keyof typeof BaseCommand.flags]: any },
+    flags: { [key in keyof typeof NetworkCommand.flags]: any },
   ): [string, NetworkFlag] {
     if (flags.url) {
       return [flags.url, 'url']
     }
 
-    const networksInfo = BaseCommand.getNetworksInfo()
+    const networksInfo = NetworkCommand.getNetworksInfo()
 
     for (const flag of Object.keys(flags) as Array<keyof typeof flags>) {
-      if (flag === 'url' || !BaseCommand.flags[flag]) continue
+      if (flag === 'url' || !NetworkCommand.flags[flag]) continue
 
       if (flags[flag]) {
         return [networksInfo[flag].url, flag]
       }
     }
 
-    return [BaseCommand.defaultUrl, 'url']
+    return [NetworkCommand.defaultUrl, 'url']
   }
 }

--- a/src/base/network.ts
+++ b/src/base/network.ts
@@ -14,7 +14,9 @@ type NetworkName = Exclude<NetworkFlag, 'url'>
  */
 export abstract class NetworkCommand extends Command {
   static flags = {
-    url: flags.string(),
+    url: flags.string({
+      char: 'u',
+    }),
     mainnet: flags.boolean({ exclusive: ['url'] }),
     ropsten: flags.boolean({ exclusive: ['url'] }),
     rinkeby: flags.boolean({ exclusive: ['url'] }),
@@ -50,11 +52,17 @@ export abstract class NetworkCommand extends Command {
   getNetworkUrlAndFlag(
     flags: { [key in keyof typeof NetworkCommand.flags]: any },
   ): [string, NetworkFlag] {
+    const networksInfo = NetworkCommand.getNetworksInfo()
+
     if (flags.url) {
+      // if a known network is specified through --url, for example `-u mainnet`, use the known url of that network
+      if (flags.url in networksInfo) {
+        const selectedNetwork = (networksInfo as any)[flags.url].url
+        return [selectedNetwork, flags.url]
+      }
+
       return [flags.url, 'url']
     }
-
-    const networksInfo = NetworkCommand.getNetworksInfo()
 
     for (const flag of Object.keys(flags) as Array<keyof typeof flags>) {
       if (flag === 'url' || !NetworkCommand.flags[flag]) continue

--- a/src/commands/contract/deploy.ts
+++ b/src/commands/contract/deploy.ts
@@ -1,13 +1,13 @@
 import { cli } from 'cli-ux'
 
-import { BaseCommand } from '../../base'
+import { NetworkCommand } from '../../base/network'
 import { privateKeyFlag } from '../../flags'
 
-export class DeployCommand extends BaseCommand {
+export class DeployCommand extends NetworkCommand {
   static description = `Deploy contract whose bytecode is in <bin> using private key <pk>.`
 
   static flags = {
-    ...BaseCommand.flags,
+    ...NetworkCommand.flags,
     pk: privateKeyFlag,
   }
 

--- a/src/commands/method/encode.ts
+++ b/src/commands/method/encode.ts
@@ -1,10 +1,10 @@
-import { BaseCommand } from '../../base'
+import { NetworkCommand } from '../../base/network'
 
-export default class EncodeCommand extends BaseCommand {
+export default class EncodeCommand extends NetworkCommand {
   static description = `Encodes the ABI for the method <methodCall> and returns the ABI byte code.`
 
   static flags = {
-    ...BaseCommand.flags,
+    ...NetworkCommand.flags,
   }
 
   static args = [

--- a/src/commands/method/send-transaction.ts
+++ b/src/commands/method/send-transaction.ts
@@ -1,13 +1,13 @@
 import { cli } from 'cli-ux'
 
-import { BaseCommand } from '../../base'
+import { NetworkCommand } from '../../base/network'
 import { privateKeyFlag } from '../../flags'
 
-export default class SendTransactionCommand extends BaseCommand {
+export default class SendTransactionCommand extends NetworkCommand {
   static description = `Sends the transaction for the contract in <address> with <encodedABI> using the given private key.`
 
   static flags = {
-    ...BaseCommand.flags,
+    ...NetworkCommand.flags,
     pk: { ...privateKeyFlag, required: true },
   }
 

--- a/src/commands/method/send.ts
+++ b/src/commands/method/send.ts
@@ -1,13 +1,13 @@
 import { cli } from 'cli-ux'
 
-import { BaseCommand } from '../../base'
+import { NetworkCommand } from '../../base/network'
 import { privateKeyFlag } from '../../flags'
 
-export default class SendCommand extends BaseCommand {
+export default class SendCommand extends NetworkCommand {
   static description = `Executes <methodCall> for the contract in <address> given <abi> using the given private key.`
 
   static flags = {
-    ...BaseCommand.flags,
+    ...NetworkCommand.flags,
     pk: { ...privateKeyFlag, required: true },
   }
 

--- a/src/commands/networks.ts
+++ b/src/commands/networks.ts
@@ -1,7 +1,7 @@
 import { Command, flags } from '@oclif/command'
 import { cli } from 'cli-ux'
 
-import { BaseCommand } from '../base/index'
+import { NetworkCommand } from '../base/network'
 
 export default class NetworksCommand extends Command {
   static description = `Show information for each known network.`
@@ -25,7 +25,7 @@ export default class NetworksCommand extends Command {
     const { flags } = this.parse(NetworksCommand)
     const { table } = flags
 
-    const networkConstants = BaseCommand.getNetworksInfo()
+    const networkConstants = NetworkCommand.getNetworksInfo()
 
     if (!table) {
       cli.styledJSON(networkConstants)

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -1,4 +1,4 @@
-import { BaseCommand } from '../base'
+import { NetworkCommand } from '../base/network'
 import { privateKeyFlag } from '../flags'
 
 const parseReplContracts = (args: string[]): Array<{ abiPath: string; address: string }> => {
@@ -13,7 +13,7 @@ const parseReplContracts = (args: string[]): Array<{ abiPath: string; address: s
   return result
 }
 
-export default class ReplCommand extends BaseCommand {
+export default class ReplCommand extends NetworkCommand {
   static description = `
 Start a REPL that connects to an RPC node ('localhost:8545' by default).
 
@@ -26,7 +26,7 @@ learn how to do this.`
   static strict = false
 
   static flags = {
-    ...BaseCommand.flags,
+    ...NetworkCommand.flags,
     pk: privateKeyFlag,
   }
 
@@ -51,7 +51,7 @@ learn how to do this.`
       const [networkUrl, networkFlag] = this.getNetworkUrlAndFlag(flags)
       const prompt =
         networkFlag === 'url'
-          ? networkUrl === BaseCommand.defaultUrl
+          ? networkUrl === NetworkCommand.defaultUrl
             ? '> '
             : `${networkUrl}> `
           : `${networkFlag}> `

--- a/src/commands/transaction/get.ts
+++ b/src/commands/transaction/get.ts
@@ -2,13 +2,13 @@ import { cli } from 'cli-ux'
 import { Transaction } from 'web3/eth/types'
 import { TransactionReceipt } from 'web3/types'
 
-import { BaseCommand } from '../../base'
+import { NetworkCommand } from '../../base/network'
 
-export default class GetCommand extends BaseCommand {
+export default class GetCommand extends NetworkCommand {
   static description = `Print the transaction object for the given transaction hash.`
 
   static flags = {
-    ...BaseCommand.flags,
+    ...NetworkCommand.flags,
   }
 
   static args = [

--- a/src/commands/transaction/nop.ts
+++ b/src/commands/transaction/nop.ts
@@ -1,13 +1,13 @@
 import { cli } from 'cli-ux'
 
-import { BaseCommand } from '../../base'
+import { NetworkCommand } from '../../base/network'
 import { privateKeyFlag } from '../../flags'
 
-export default class NopCommand extends BaseCommand {
+export default class NopCommand extends NetworkCommand {
   static description = `Generates a transaction that does nothing with the given private key.`
 
   static flags = {
-    ...BaseCommand.flags,
+    ...NetworkCommand.flags,
     pk: { ...privateKeyFlag, required: true },
   }
 


### PR DESCRIPTION
Closes #47.

With this PR, you can specify the network using `--url/-u`. In other words, `-u mainnet` is equivalent to `--mainnet`. Maybe this should be the only way and we should deprecate `--mainnet`-like flags.

## Cute animal picture

![image](https://user-images.githubusercontent.com/417134/63172266-afed8000-c013-11e9-92bf-279e6c58801a.png)
