### PR TITLE
Propose to consider ERCRef as a sibling projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ you will have `toWei` and `fromWei` as global functions in the REPL.
 ## Sibling projects
 
 - [Solhint](https://github.com/protofire/solhint): A linter for the Solidity language.
+- [ERCRef](https://github.com/ercref/ercref-contracts): a repository for ERC referecen implementations. See [this issue](https://github.com/ercref/ercref-contracts/pull/43) for usage.
 
 ## Back us
 


### PR DESCRIPTION
Propose to consider [ERCRef](https://github.com/ercref/ercref-contracts) as a sibling projects that [make uses of eth-cli](https://github.com/ercref/ercref-contracts/pull/43)

## Cute animal picture
![cute dog](https://upload.wikimedia.org/wikipedia/commons/4/43/Cute_dog.jpg)

<!-- Include a picture of a cute animal. This is not mandatory, but the reviewers will be very sad if you don't do it. -->
